### PR TITLE
feat: add conveior_elasticsearch_indices_store_size metric

### DIFF
--- a/source-code/conveior/bin/metrics-elasticsearch.sh
+++ b/source-code/conveior/bin/metrics-elasticsearch.sh
@@ -22,6 +22,25 @@ do
     METRICS=$(echo -e "$METRICS\n$METRIC")
     METRIC="conveior_elasticsearch{label_name=\"red\"} ${RED}"
     METRICS=$(echo -e "$METRICS\n$METRIC")
+
+    # Execute the command with correctly expanded variables
+    export JSON_DATA=$(docker exec -i ${POD} curl -s --user "${ELASTICSEARCH_USERNAME}:${ELASTICSEARCH_PASSWORD}" "http://127.0.0.1:9200/_cat/indices?format=json&bytes=b")
+
+    for row in $(echo "${JSON_DATA}" | jq -c '.[]'); do
+      health=$(echo "${row}" | jq -r '.health')
+      status=$(echo "${row}" | jq -r '.status')
+      index=$(echo "${row}" | jq -r '.index')
+      uuid=$(echo "${row}" | jq -r '.uuid')
+      pri=$(echo "${row}" | jq -r '.pri')
+      rep=$(echo "${row}" | jq -r '.rep')
+      docs_count=$(echo "${row}" | jq -r '.["docs.count"]')
+      docs_deleted=$(echo "${row}" | jq -r '.["docs.deleted"]')
+      store_size=$(echo "${row}" | jq -r '.["store.size"]')
+      pri_store_size=$(echo "${row}" | jq -r '.["pri.store.size"]')
+
+      labels="health=\"${health}\",status=\"${status}\",index=\"${index}\",uuid=\"${uuid}\",pri=\"${pri}\",rep=\"${rep}\",docs_count=\"${docs_count}\",docs_deleted=\"${docs_deleted}\",pri_store_size=\"${pri_store_size}\""
+      METRICS=$(echo -e "$METRICS\nconveior_elasticsearch_indices_store_size{${labels}} ${store_size}")
+    done
   fi
 done
 


### PR DESCRIPTION
Added conveior_elasticsearch_indices_store_size for gathering all available details about elasticsearch indexes. Details added as labels & values, while the metric value is filled with the index store_size.