### PR TITLE
feat: add --single-transaction option to mysqldump command

### DIFF
--- a/source-code/conveior/bin/backup-mysql-k8s.sh
+++ b/source-code/conveior/bin/backup-mysql-k8s.sh
@@ -47,7 +47,7 @@ do
     done
     echo_message "Found DBs: ${DATABASES_STR}"
     if [[ "${DATABASES_STR}" != "" ]]; then
-      kubectl -n "${POD_NAMESPACE}" exec -i "${POD}" -- bash -c "mysqldump --user=${SQL_USER} --password='${SQL_PASS}' --extended-insert --databases ${DATABASES_STR} > /tmp/${FILE} 2>/dev/null"
+      kubectl -n "${POD_NAMESPACE}" exec -i "${POD}" -- bash -c "mysqldump --user=${SQL_USER} --password='${SQL_PASS}' --single-transaction --extended-insert --databases ${DATABASES_STR} > /tmp/${FILE} 2>/dev/null"
       kubectl cp "${POD_NAMESPACE}/${POD}:/tmp/${FILE}" "${SERVER_DIR}/${FILE}" >/dev/null
       kubectl -n "${POD_NAMESPACE}" exec -i "${POD}" -- bash -c "rm /tmp/${FILE}"
 

--- a/source-code/conveior/bin/backup-mysql.sh
+++ b/source-code/conveior/bin/backup-mysql.sh
@@ -28,7 +28,7 @@ do
   mkdir -p "${SERVER_DIR}"
   find "${SERVER_DIR}" -mindepth 1 -delete
 
-  docker exec -i "${POD}" bash -c "mysqldump --user=${SQL_USER} --password='${SQL_PASS}' --extended-insert --databases ${DATABASES_STR} > /tmp/${FILE} 2>/dev/null"
+  docker exec -i "${POD}" bash -c "mysqldump --user=${SQL_USER} --password='${SQL_PASS}' --single-transaction --extended-insert --databases ${DATABASES_STR} > /tmp/${FILE} 2>/dev/null"
   docker cp "${POD}":/tmp/${FILE} ${SERVER_DIR}
   docker exec -i "${POD}" bash -c "rm /tmp/${FILE}"
 


### PR DESCRIPTION
- Added the --single-transaction flag to mysqldump to prevent table locking during backups.
- This change improves backup performance and reduces impact on the database during dump operations.